### PR TITLE
Add KRAKEN-TOOL initial structure

### DIFF
--- a/KRAKEN-TOOL/README.md
+++ b/KRAKEN-TOOL/README.md
@@ -1,0 +1,31 @@
+# KRAKEN-TOOL
+
+KRAKEN-TOOL est un projet éducatif regroupant divers outils d'OSINT et de pentest. Chaque fonctionnalité est implémentée dans un module séparé dans le dossier `modules/` et peut être appelée via un menu interactif dans le terminal.
+
+## Installation
+
+1. Clonez ce dépôt.
+2. Installez les dépendances :
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Lancez le programme :
+   ```bash
+   python main.py
+   ```
+
+## Structure
+
+- `main.py` : menu principal qui appelle les modules.
+- `modules/` : répertoire contenant chaque outil sous forme de module Python.
+- `requirements.txt` : liste des dépendances nécessaires.
+
+## Modules disponibles
+
+Pour l'instant, trois modules de base sont inclus :
+
+- **Whois Lookup** : récupère les informations WHOIS d'un domaine.
+- **DNS Lookup** : résout les enregistrements DNS A d'un domaine.
+- **IP Tracker** : localise une adresse IP via ip-api.
+
+D'autres modules seront ajoutés pour atteindre environ 50 fonctionnalités.

--- a/KRAKEN-TOOL/main.py
+++ b/KRAKEN-TOOL/main.py
@@ -1,0 +1,40 @@
+import sys
+from colorama import init, Fore
+from pyfiglet import figlet_format
+
+from modules import whois_lookup, dns_lookup, ip_tracker
+
+init(autoreset=True)
+
+
+def banner():
+    print(Fore.CYAN + figlet_format("KRAKEN TOOL", font="slant"))
+
+
+def menu():
+    print(Fore.GREEN + "1. Whois Lookup")
+    print(Fore.GREEN + "2. DNS Lookup")
+    print(Fore.GREEN + "3. IP Tracker")
+    print(Fore.RED + "0. Exit")
+
+
+def main():
+    banner()
+    while True:
+        menu()
+        choice = input(Fore.YELLOW + "Select an option: ")
+        if choice == '1':
+            whois_lookup.run()
+        elif choice == '2':
+            dns_lookup.run()
+        elif choice == '3':
+            ip_tracker.run()
+        elif choice == '0':
+            print(Fore.CYAN + "Goodbye!")
+            sys.exit()
+        else:
+            print(Fore.RED + "Invalid choice. Try again.")
+
+
+if __name__ == "__main__":
+    main()

--- a/KRAKEN-TOOL/modules/dns_lookup.py
+++ b/KRAKEN-TOOL/modules/dns_lookup.py
@@ -1,0 +1,16 @@
+"""DNS Lookup Module"""
+
+import dns.resolver
+from colorama import Fore
+
+
+def run():
+    print(Fore.CYAN + "[DNS Lookup]")
+    print("Enter a domain to resolve DNS records (A records).")
+    domain = input("Domain: ")
+    try:
+        answers = dns.resolver.resolve(domain, 'A')
+        for rdata in answers:
+            print(f"A Record: {rdata.address}")
+    except Exception as e:
+        print(Fore.RED + f"Error: {e}")

--- a/KRAKEN-TOOL/modules/ip_tracker.py
+++ b/KRAKEN-TOOL/modules/ip_tracker.py
@@ -1,0 +1,22 @@
+"""IP Tracker Module"""
+
+import requests
+from colorama import Fore
+
+API_URL = "http://ip-api.com/json/"  # No API key needed
+
+
+def run():
+    print(Fore.CYAN + "[IP Tracker]")
+    print("Enter an IP address to geolocate.")
+    ip = input("IP Address: ")
+    try:
+        response = requests.get(API_URL + ip, timeout=10)
+        data = response.json()
+        if data.get("status") == "success":
+            for key in ["query", "country", "regionName", "city", "isp", "org", "lat", "lon"]:
+                print(f"{key}: {data.get(key)}")
+        else:
+            print(Fore.RED + "Lookup failed")
+    except Exception as e:
+        print(Fore.RED + f"Error: {e}")

--- a/KRAKEN-TOOL/modules/whois_lookup.py
+++ b/KRAKEN-TOOL/modules/whois_lookup.py
@@ -1,0 +1,16 @@
+"""Whois Lookup Module"""
+
+import whois
+from colorama import Fore
+
+
+def run():
+    print(Fore.CYAN + "[Whois Lookup]")
+    print("Enter a domain to fetch WHOIS information.")
+    domain = input("Domain: ")
+    try:
+        data = whois.whois(domain)
+        for key, value in data.items():
+            print(f"{key}: {value}")
+    except Exception as e:
+        print(Fore.RED + f"Error: {e}")

--- a/KRAKEN-TOOL/requirements.txt
+++ b/KRAKEN-TOOL/requirements.txt
@@ -1,0 +1,5 @@
+colorama
+pyfiglet
+python-whois
+dnspython
+requests


### PR DESCRIPTION
## Summary
- create basic OSINT tool framework `KRAKEN-TOOL`
- add interactive ASCII menu
- implement three starter modules: whois, DNS lookup and IP tracker
- include README and requirements list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6868389deb44832c85c060a8c71e996c